### PR TITLE
Minor typo fix that was breaking link to the blog post with description

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,4 +17,4 @@ This research is designed to show the accessibility of backplane network visibil
 
 ## More information / Technical documentation
 
-This code represents the proof of concept state of the research. More information can be found in the accompanying [blog post](blog.talosintelligence.com/badgerboard-research).
+This code represents the proof of concept state of the research. More information can be found in the accompanying [blog post](https://blog.talosintelligence.com/badgerboard-research).


### PR DESCRIPTION
missing https:// in link was making link to blog post not work